### PR TITLE
Fix travis

### DIFF
--- a/.dockerignore
+++ b/.dockerignore
@@ -1,0 +1,1 @@
+config/master.key

--- a/.travis.yml
+++ b/.travis.yml
@@ -2,7 +2,7 @@ language: ruby
 rvm:
   - 2.5.1
 cache: bundler
-sudo: required
+sudo: false
 services:
   - docker
 

--- a/.travis.yml
+++ b/.travis.yml
@@ -3,6 +3,7 @@ rvm:
   - 2.5.1
 cache: bundler
 sudo: false
+bundler_args: --with test
 services:
   - docker
 
@@ -11,8 +12,8 @@ before_install:
   - docker-compose build
   - docker ps
 
+after_install:
   # setup testing db
-  - docker-compose run -T --rm -e RAILS_ENV=test --entrypoint="bundle install" zoo_stats
   - docker-compose run -T --rm -e RAILS_ENV=test --entrypoint="bundle exec rake db:setup" zoo_stats
 
 script:

--- a/.travis.yml
+++ b/.travis.yml
@@ -1,7 +1,6 @@
 language: ruby
 rvm:
   - 2.5.1
-cache: bundler
 sudo: false
 services:
   - docker
@@ -14,6 +13,8 @@ before_install:
   # setup testing db
   - docker-compose run -T --rm -e RAILS_ENV=test --entrypoint="bundle install" zoo_stats
   - docker-compose run -T --rm -e RAILS_ENV=test --entrypoint="bundle exec rake db:setup" zoo_stats
+
+install:
 
 script:
   - docker-compose run -T --rm -e RAILS_ENV=test --entrypoint="bundle exec rspec" zoo_stats

--- a/.travis.yml
+++ b/.travis.yml
@@ -3,7 +3,6 @@ rvm:
   - 2.5.1
 cache: bundler
 sudo: false
-bundler_args: --with test
 services:
   - docker
 
@@ -12,8 +11,8 @@ before_install:
   - docker-compose build
   - docker ps
 
-after_install:
   # setup testing db
+  - docker-compose run -T --rm -e RAILS_ENV=test --entrypoint="bundle install" zoo_stats
   - docker-compose run -T --rm -e RAILS_ENV=test --entrypoint="bundle exec rake db:setup" zoo_stats
 
 script:

--- a/.travis.yml
+++ b/.travis.yml
@@ -2,7 +2,7 @@ language: ruby
 rvm:
   - 2.5.1
 cache: bundler
-sudo: false
+sudo: required
 services:
   - docker
 

--- a/.travis.yml
+++ b/.travis.yml
@@ -3,7 +3,6 @@ rvm:
   - 2.5.1
 cache: bundler
 sudo: false
-bundler_args: --with test
 services:
   - docker
 
@@ -13,6 +12,7 @@ before_install:
   - docker ps
 
   # setup testing db
+  - docker-compose run -T --rm -e RAILS_ENV=test --entrypoint="bundle install" zoo_stats
   - docker-compose run -T --rm -e RAILS_ENV=test --entrypoint="bundle exec rake db:setup" zoo_stats
 
 script:

--- a/.travis.yml
+++ b/.travis.yml
@@ -10,11 +10,12 @@ before_install:
   - docker-compose build
   - docker ps
 
-  # setup testing db
-  - docker-compose run -T --rm -e RAILS_ENV=test --entrypoint="bundle install" zoo_stats
-  - docker-compose run -T --rm -e RAILS_ENV=test --entrypoint="bundle exec rake db:setup" zoo_stats
-
 install:
+  - docker-compose run -T --rm -e RAILS_ENV=test --entrypoint="bundle install" zoo_stats
+
+after_install:
+  # setup testing db
+  - docker-compose run -T --rm -e RAILS_ENV=test --entrypoint="bundle exec rake db:setup" zoo_stats
 
 script:
   - docker-compose run -T --rm -e RAILS_ENV=test --entrypoint="bundle exec rspec" zoo_stats

--- a/.travis.yml
+++ b/.travis.yml
@@ -3,6 +3,7 @@ rvm:
   - 2.5.1
 cache: bundler
 sudo: false
+bundler_args: --with test
 services:
   - docker
 
@@ -12,7 +13,6 @@ before_install:
   - docker ps
 
   # setup testing db
-  - docker-compose run -T --rm -e RAILS_ENV=test --entrypoint="bundle install" zoo_stats
   - docker-compose run -T --rm -e RAILS_ENV=test --entrypoint="bundle exec rake db:setup" zoo_stats
 
 script:

--- a/.travis.yml
+++ b/.travis.yml
@@ -13,6 +13,7 @@ before_install:
   - docker ps
 
   # setup testing db
+  - docker-compose run -T --rm -e RAILS_ENV=test --entrypoint="bundle install" zoo_stats
   - docker-compose run -T --rm -e RAILS_ENV=test --entrypoint="bundle exec rake db:setup" zoo_stats
 
 script:

--- a/.travis.yml
+++ b/.travis.yml
@@ -13,7 +13,7 @@ before_install:
 install:
   - docker-compose run -T --rm -e RAILS_ENV=test --entrypoint="bundle install" zoo_stats
 
-after_install:
+before_script:
   # setup testing db
   - docker-compose run -T --rm -e RAILS_ENV=test --entrypoint="bundle exec rake db:setup" zoo_stats
 

--- a/.travis.yml
+++ b/.travis.yml
@@ -3,7 +3,6 @@ rvm:
   - 2.5.1
 cache: bundler
 sudo: false
-bundler_args: --without development production
 services:
   - docker
 

--- a/.travis.yml
+++ b/.travis.yml
@@ -12,9 +12,8 @@ before_install:
   - docker-compose build
   - docker ps
 
-  # setup testing environment
-  # - docker-compose run --rm -e RAILS_ENV=test --entrypoint="bundle install --with=test" zoo_stats
-  - docker-compose run --rm -e RAILS_ENV=test --entrypoint="bundle exec rake db:setup" zoo_stats
+  # setup testing db
+  - docker-compose run -T --rm -e RAILS_ENV=test --entrypoint="bundle exec rake db:setup" zoo_stats
 
 script:
   - docker-compose run -T --rm -e RAILS_ENV=test --entrypoint="bundle exec rspec" zoo_stats

--- a/Dockerfile.dev
+++ b/Dockerfile.dev
@@ -14,12 +14,10 @@ ADD ./Gemfile /rails_app/
 ADD ./Gemfile.lock /rails_app/
 
 RUN bundle config --global jobs `cat /proc/cpuinfo | grep processor | wc -l | xargs -I % expr % - 1`
-RUN bundle install --without development test
+RUN bundle install
 
 ADD supervisord.conf /etc/supervisor/conf.d/zoo-events-stats-postgres.conf
 ADD ./ /rails_app/
-
-RUN (cd /rails_app && git log --format="%H" -n 1 > commit_id.txt)
 
 EXPOSE 80
 

--- a/Dockerfile.dev
+++ b/Dockerfile.dev
@@ -14,7 +14,6 @@ ADD ./Gemfile /rails_app/
 ADD ./Gemfile.lock /rails_app/
 
 RUN bundle config --global jobs `cat /proc/cpuinfo | grep processor | wc -l | xargs -I % expr % - 1`
-RUN bundle install
 
 ADD supervisord.conf /etc/supervisor/conf.d/zoo-events-stats-postgres.conf
 ADD ./ /rails_app/

--- a/Gemfile
+++ b/Gemfile
@@ -51,7 +51,3 @@ group :test do
   gem 'rspec-graphql_matchers'
   gem 'shoulda-matchers', '~> 3.1', '>= 3.1.2'
 end
-
-
-# Windows does not include zoneinfo files, so bundle the tzinfo-data gem
-gem 'tzinfo-data', platforms: [:mingw, :mswin, :x64_mingw, :jruby]

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -14,7 +14,7 @@ gem_cache:
     - /gem_cache
 
 zoo_stats:
-  dockerfile: Dockerfile
+  dockerfile: Dockerfile.dev
   build: ./
   volumes:
     - ./:/rails_app

--- a/scripts/docker/start.sh
+++ b/scripts/docker/start.sh
@@ -1,11 +1,7 @@
 #!/bin/bash -ex
-
 cd /rails_app
-
-tmpreaper 7d /tmp/
 
 mkdir -p tmp/pids/
 rm -f tmp/pids/*.pid
 
-bundle check || bundle install --binstubs="$BUNDLE_BIN"
 exec /usr/bin/supervisord -c /etc/supervisor/supervisord.conf


### PR DESCRIPTION
allow the test / development environment gems to be installed for the travis runs using docker containers

- added a Dockerfile.dev which is a copy of the Dockerfile but installs all gems (keep production lean)
- ensure the travis specs can run
- ensure we never leak the master.key via docker images.